### PR TITLE
Add setup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# SoAWebApp
+
+This repository contains a Flask backend and a React frontend.
+
+## Backend setup
+
+```
+python -m venv .venv
+# On Windows
+.\.venv\Scripts\Activate.ps1
+# On macOS/Linux
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+To run the backend locally:
+
+```
+python app.py
+```
+
+The app will start with debug mode enabled and will initialize the SQLite database if it doesn't exist.
+
+## Frontend setup
+
+The React frontend lives in the `soa-editor` directory.
+
+```
+cd soa-editor
+npm install
+npm run dev
+```
+
+This starts the Vite dev server with hot reload enabled.
+


### PR DESCRIPTION
## Summary
- add instructions for backend virtual environment and running the Flask app
- document frontend installation and development server steps

## Testing
- `pytest -q`
- `cd soa-editor && npm run lint` *(fails: Unexpected any errors)*
- `npm run build`
- `npm run dev` *(manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_684c452f8960832cab7476f16a847a69