### PR TITLE
Add DB management features

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -27,6 +27,7 @@ from backend.app.routes.r_shop_inventory import bp as shop_inventory_bp
 from backend.app.routes.r_stats import bp as stats_bp
 from backend.app.routes.r_story_arcs import bp as story_arcs_bp
 from backend.app.routes.r_timelines import bp as timelines_bp
+from backend.app.routes.r_db_admin import bp as db_admin_bp
 
 def create_app() -> Flask:
     app = Flask(__name__)
@@ -72,7 +73,8 @@ def create_app() -> Flask:
         shop_inventory_bp,
         stats_bp,
         story_arcs_bp,
-        timelines_bp
+        timelines_bp,
+        db_admin_bp
     ]
     
     for blueprint in blueprints:

--- a/backend/app/routes/r_db_admin.py
+++ b/backend/app/routes/r_db_admin.py
@@ -1,0 +1,59 @@
+from flask import Blueprint, request, jsonify, abort
+from backend.app.config import DATA_DIR, SQLALCHEMY_DATABASE_URI
+from backend.app.models.base import Base
+from backend.app.db.init_db import engine as main_engine
+from sqlalchemy import create_engine
+import os
+import re
+
+bp = Blueprint('db_admin', __name__)
+
+# Helper to sanitize database names
+_name_re = re.compile(r'[^a-zA-Z0-9_]+')
+
+def _db_path(name: str):
+    name = _name_re.sub('', name).lower() or 'preview'
+    return DATA_DIR / f"db_{name}.sqlite"
+
+@bp.route('/api/db/create', methods=['POST'])
+def create_db():
+    data = request.get_json(silent=True) or {}
+    name = data.get('name', 'preview')
+    path = _db_path(name)
+    if path.exists():
+        abort(400, description='Database already exists')
+    engine = create_engine(f'sqlite:///{path}')
+    Base.metadata.create_all(bind=engine)
+    engine.dispose()
+    return jsonify({'status': 'ok', 'path': str(path)})
+
+@bp.route('/api/db/delete', methods=['POST'])
+def delete_db():
+    data = request.get_json(silent=True) or {}
+    name = data.get('name', 'preview')
+    path = _db_path(name)
+    main_path = SQLALCHEMY_DATABASE_URI.replace('sqlite:///', '')
+    if str(path) == main_path:
+        abort(400, description='Cannot delete active database')
+    if path.exists():
+        os.remove(path)
+        return jsonify({'status': 'ok'})
+    abort(404, description='Database not found')
+
+@bp.route('/api/db/list', methods=['GET'])
+def list_dbs():
+    files = [f.name for f in DATA_DIR.glob('db_*.sqlite')]
+    main_path = SQLALCHEMY_DATABASE_URI.replace('sqlite:///', '')
+    main_name = os.path.basename(main_path)
+    if (DATA_DIR / main_name).exists():
+        files.insert(0, main_name)
+    return jsonify({'databases': files, 'active': main_name})
+
+
+@bp.route('/api/db/reset', methods=['POST'])
+def reset_db():
+    """Drop and recreate all tables on the active database."""
+    Base.metadata.drop_all(bind=main_engine)
+    Base.metadata.create_all(bind=main_engine)
+    main_engine.dispose()
+    return jsonify({'status': 'ok'})

--- a/soa-editor/src/components/Layout.tsx
+++ b/soa-editor/src/components/Layout.tsx
@@ -1,13 +1,27 @@
 import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
+import { useEffect, useState } from 'react';
 
 export default function Layout({ collapsed, onToggleCollapse }: { collapsed: boolean; onToggleCollapse: () => void }) {
+  const [activeDb, setActiveDb] = useState('');
+
+  useEffect(() => {
+    fetch('/api/db/list')
+      .then((r) => r.json())
+      .then((data) => setActiveDb(data.active));
+  }, []);
+
   return (
-    <div className="flex">
-      <Sidebar collapsed={collapsed} onToggleCollapse={onToggleCollapse} />
-      <main className="flex-1 overflow-y-auto">
-        <Outlet />
-      </main>
+    <div className="flex flex-col h-screen">
+      <div className="bg-slate-800 text-white px-4 py-2 text-sm">
+        Active database: {activeDb || 'loading...'}
+      </div>
+      <div className="flex flex-1">
+        <Sidebar collapsed={collapsed} onToggleCollapse={onToggleCollapse} />
+        <main className="flex-1 overflow-y-auto">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 }

--- a/soa-editor/src/components/Sidebar.tsx
+++ b/soa-editor/src/components/Sidebar.tsx
@@ -77,7 +77,10 @@ function SortableSidebarItem({ to, label, icon: Icon, collapsed, hidden, groupLa
 const DEFAULT_GROUPS = [
   {
     label: 'System',
-    items: [ { to: '/', label: 'Home', icon: HomeIcon } ],
+    items: [
+      { to: '/', label: 'Home', icon: HomeIcon },
+      { to: '/db', label: 'Database Manager', icon: BeakerIcon }
+    ],
   },
   {
     label: 'Gameplay',

--- a/soa-editor/src/main.tsx
+++ b/soa-editor/src/main.tsx
@@ -26,6 +26,7 @@ import ShopsInventoryEditorPage from "./pages/ShopsInventoryEditor";
 import StatsEditorPage from "./pages/StatsEditor";
 import StoryArcsEditorPage from "./pages/StoryArcsEditor";
 import TimelinesEditorPage from "./pages/TimelinesEditor";
+import DatabaseManagerPage from "./pages/DatabaseManagerPage";
 import './index.css';
 import './App.css';
 import Layout from './components/Layout';
@@ -68,6 +69,7 @@ const MainApp = () => {
             <Route path="stats" element={<StatsEditorPage />} />
             <Route path="story-arcs" element={<StoryArcsEditorPage />} />
             <Route path="timelines" element={<TimelinesEditorPage />} />
+            <Route path="db" element={<DatabaseManagerPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/soa-editor/src/pages/DatabaseManagerPage.tsx
+++ b/soa-editor/src/pages/DatabaseManagerPage.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+
+export default function DatabaseManagerPage() {
+  const [dbs, setDbs] = useState<string[]>([]);
+  const [active, setActive] = useState('');
+  const [name, setName] = useState('preview');
+
+  const loadDbs = () => {
+    fetch('/api/db/list')
+      .then((r) => r.json())
+      .then((data) => {
+        setDbs(data.databases || []);
+        setActive(data.active);
+      });
+  };
+
+  useEffect(() => { loadDbs(); }, []);
+
+  const createDb = async () => {
+    await fetch('/api/db/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    });
+    loadDbs();
+  };
+
+  const deleteDb = async (n: string) => {
+    if (!window.confirm(`Delete database ${n}?`)) return;
+    await fetch('/api/db/delete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: n.replace('db_','').replace('.sqlite','') })
+    });
+    loadDbs();
+  };
+
+  const resetDb = async () => {
+    if (!window.confirm('Reset main database? This will delete all data.')) return;
+    await fetch('/api/db/reset', { method: 'POST' });
+    loadDbs();
+  };
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold mb-4">Database Manager</h1>
+      <p className="mb-4">Active database: <strong>{active}</strong></p>
+      <div className="flex items-center gap-2 mb-6">
+        <input
+          value={name}
+          onChange={e => setName(e.target.value)}
+          className="border p-2 rounded"
+          placeholder="database name"
+        />
+        <button onClick={createDb} className="bg-blue-600 text-white px-3 py-1 rounded">
+          Create
+        </button>
+        <button onClick={resetDb} className="ml-4 bg-orange-600 text-white px-3 py-1 rounded">
+          Reset Main
+        </button>
+      </div>
+      <ul className="space-y-2">
+        {dbs.map(db => (
+          <li key={db} className="flex items-center gap-2">
+            <span className="flex-1">{db}</span>
+            {db !== active ? (
+              <button
+                onClick={() => deleteDb(db)}
+                className="bg-red-600 text-white px-2 py-1 rounded"
+              >
+                Delete
+              </button>
+            ) : (
+              <span className="text-sm text-gray-500">Active</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/soa-editor/src/pages/IndexPageEditor.tsx
+++ b/soa-editor/src/pages/IndexPageEditor.tsx
@@ -49,6 +49,7 @@ const IndexPage = () => {
     { path: '/stats', name: 'Stats Editor' },
     { path: '/story-arcs', name: 'Story Arcs Editor' },
     { path: '/timelines', name: 'Timelines Editor' },
+    { path: '/db', name: 'Database Manager' },
   ];
 
 const pageIcons: Record<string, React.ElementType> = {
@@ -74,6 +75,7 @@ const pageIcons: Record<string, React.ElementType> = {
   '/stats': ChartBarIcon,
   '/story-arcs': Squares2X2Icon,
   '/timelines': ClockIcon,
+  '/db': BeakerIcon,
 };
 
 


### PR DESCRIPTION
## Summary
- support dynamic database creation and deletion with new Flask blueprint
- register new DB admin blueprint in app factory
- add Database Manager page to React frontend
- update sidebar, index, and routing to include DB management
- expose active DB label in layout and allow resetting main DB

## Testing
- `npm run lint` *(fails: React and TypeScript lint errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711239bbcc832c9dbc2caaade29fa4