### PR TITLE
Add database import UI

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -27,6 +27,7 @@ from backend.app.routes.r_shop_inventory import bp as shop_inventory_bp
 from backend.app.routes.r_stats import bp as stats_bp
 from backend.app.routes.r_story_arcs import bp as story_arcs_bp
 from backend.app.routes.r_timelines import bp as timelines_bp
+from backend.app.routes.r_import import bp as import_bp
 
 def create_app() -> Flask:
     app = Flask(__name__)
@@ -72,7 +73,8 @@ def create_app() -> Flask:
         shop_inventory_bp,
         stats_bp,
         story_arcs_bp,
-        timelines_bp
+        timelines_bp,
+        import_bp
     ]
     
     for blueprint in blueprints:

--- a/backend/app/routes/r_import.py
+++ b/backend/app/routes/r_import.py
@@ -1,0 +1,95 @@
+from flask import Blueprint, request, jsonify, abort
+from backend.app.models import ALL_MODELS
+from backend.app.models.base import Base
+from backend.app.db.init_db import get_db_session, engine
+from sqlalchemy.types import JSON as JSONType, Enum as EnumType
+import csv
+import io
+import json
+import os
+import zipfile
+
+# Mapping of table name to model class
+TABLE_TO_MODEL = {model.__tablename__: model for model in ALL_MODELS}
+
+bp = Blueprint('data_import', __name__)
+
+def _read_csv(file_obj):
+    text = io.TextIOWrapper(file_obj, encoding='utf-8')
+    reader = csv.DictReader(text)
+    return [row for row in reader]
+
+def _parse_zip(uploaded):
+    data = {}
+    with zipfile.ZipFile(uploaded.stream) as z:
+        for name in z.namelist():
+            if name.endswith('.csv'):
+                table = os.path.splitext(os.path.basename(name))[0]
+                with z.open(name) as f:
+                    data[table] = _read_csv(f)
+    return data
+
+def _convert_value(column, value):
+    if value in (None, ""):
+        return None
+    if isinstance(column.type, JSONType):
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return None
+    if isinstance(column.type, EnumType):
+        return column.type.enum_class(value)
+    return value
+
+def _create_instance(model, record):
+    processed = {}
+    for column in model.__table__.columns:
+        if column.name in record:
+            processed[column.name] = _convert_value(column, record[column.name])
+    return model(**processed)
+
+@bp.route('/api/import', methods=['POST'])
+def import_data():
+    if 'file' not in request.files:
+        abort(400, description='No file provided')
+    uploaded = request.files['file']
+    if uploaded.filename == '':
+        abort(400, description='Empty filename')
+
+    try:
+        if uploaded.filename.endswith('.zip'):
+            parsed = _parse_zip(uploaded)
+        elif uploaded.filename.endswith('.csv'):
+            table = os.path.splitext(uploaded.filename)[0]
+            parsed = {table: _read_csv(uploaded.stream)}
+        else:  # assume JSON
+            parsed = json.load(uploaded.stream)
+            if isinstance(parsed, list):
+                table = os.path.splitext(uploaded.filename)[0]
+                parsed = {table: parsed}
+    except Exception as e:
+        abort(400, description=f'Failed to parse file: {e}')
+
+    db_session = get_db_session()
+    try:
+        Base.metadata.drop_all(bind=engine)
+        Base.metadata.create_all(bind=engine)
+
+        for table in Base.metadata.sorted_tables:
+            name = table.name
+            if name in parsed:
+                model = TABLE_TO_MODEL.get(name)
+                if not model:
+                    continue
+                for record in parsed[name]:
+                    instance = _create_instance(model, record)
+                    db_session.add(instance)
+        db_session.commit()
+        return jsonify({"status": "ok"})
+    except Exception as e:
+        db_session.rollback()
+        abort(400, description=str(e))
+    finally:
+        db_session.close()
+

--- a/soa-editor/src/components/Sidebar.tsx
+++ b/soa-editor/src/components/Sidebar.tsx
@@ -77,7 +77,10 @@ function SortableSidebarItem({ to, label, icon: Icon, collapsed, hidden, groupLa
 const DEFAULT_GROUPS = [
   {
     label: 'System',
-    items: [ { to: '/', label: 'Home', icon: HomeIcon } ],
+    items: [
+      { to: '/', label: 'Home', icon: HomeIcon },
+      { to: '/db-tools', label: 'Database Tools', icon: DocumentTextIcon },
+    ],
   },
   {
     label: 'Gameplay',

--- a/soa-editor/src/main.tsx
+++ b/soa-editor/src/main.tsx
@@ -26,6 +26,7 @@ import ShopsInventoryEditorPage from "./pages/ShopsInventoryEditor";
 import StatsEditorPage from "./pages/StatsEditor";
 import StoryArcsEditorPage from "./pages/StoryArcsEditor";
 import TimelinesEditorPage from "./pages/TimelinesEditor";
+import DatabaseToolsPage from "./pages/DatabaseTools";
 import './index.css';
 import './App.css';
 import Layout from './components/Layout';
@@ -68,6 +69,7 @@ const MainApp = () => {
             <Route path="stats" element={<StatsEditorPage />} />
             <Route path="story-arcs" element={<StoryArcsEditorPage />} />
             <Route path="timelines" element={<TimelinesEditorPage />} />
+            <Route path="db-tools" element={<DatabaseToolsPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/soa-editor/src/pages/DatabaseTools.tsx
+++ b/soa-editor/src/pages/DatabaseTools.tsx
@@ -1,0 +1,83 @@
+import { useState, useRef } from 'react';
+
+export default function DatabaseTools() {
+  const [file, setFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [toast, setToast] = useState<{type:'success'|'error', message:string}|null>(null);
+  const toastTimeout = useRef<ReturnType<typeof setTimeout>|null>(null);
+  const confirmRef = useRef<HTMLDialogElement>(null);
+
+  const showToast = (type:'success'|'error', message:string) => {
+    setToast({type, message});
+    if (toastTimeout.current) clearTimeout(toastTimeout.current);
+    toastTimeout.current = setTimeout(() => setToast(null), 3000);
+  };
+
+  const doUpload = async () => {
+    if (!file) return;
+    setUploading(true);
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const res = await fetch('http://localhost:5000/api/import', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || 'Upload failed');
+      }
+      showToast('success', 'Import completed');
+      setTimeout(() => window.location.reload(), 500);
+    } catch (e:any) {
+      showToast('error', e.message);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const confirmUpload = () => confirmRef.current?.showModal();
+  const handleConfirm = () => { confirmRef.current?.close(); doUpload(); };
+  const handleCancel = () => { confirmRef.current?.close(); };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Database Tools</h1>
+      <div className="flex items-center gap-2">
+        <input
+          type="file"
+          accept=".csv,.json,.zip"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          className="file-input file-input-bordered"
+        />
+        <button
+          className="btn btn-primary"
+          disabled={!file || uploading}
+          onClick={confirmUpload}
+        >
+          {uploading && <span className="loading loading-spinner"></span>}
+          {!uploading && 'Upload & Replace'}
+        </button>
+      </div>
+
+      <dialog ref={confirmRef} className="modal">
+        <form method="dialog" className="modal-box">
+          <h3 className="font-bold text-lg">Confirm Import</h3>
+          <p className="py-4">This will erase current data. Continue?</p>
+          <div className="modal-action">
+            <button type="button" className="btn btn-error" onClick={handleConfirm}>Import</button>
+            <button type="button" className="btn" onClick={handleCancel}>Cancel</button>
+          </div>
+        </form>
+      </dialog>
+
+      {toast && (
+        <div className="toast toast-top toast-end z-50 fixed right-4 top-4">
+          <div className={`alert ${toast.type === 'success' ? 'alert-success' : 'alert-error'} shadow-lg`}>
+            <span>{toast.message}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- build data import page with file picker and upload logic
- register new page via sidebar and routing
- connect to `/api/import` backend endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm --prefix soa-editor run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix soa-editor run build` *(fails: missing dependencies like 'react/jsx-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_687111f53bb8832c9fa395a9f3e5e0b0