### PR TITLE
Add database export endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,20 @@ npm run dev
 
 This starts the Vite dev server with hot reload enabled.
 
+## Exporting Data
+
+The backend exposes an `/api/export` endpoint for dumping the database
+contents in a format that can be imported into Unreal Engine 5:
+
+```
+GET /api/export?format=csv        # Returns a ZIP of CSV files (default)
+GET /api/export?format=json       # Returns a JSON file
+GET /api/export?format=csv&tables=items,quests
+```
+
+When exporting as CSV the first column header is `Name`, containing the
+record's ID so it can be used as the row key in UE5 DataTables.
+
+The React frontend exposes these exports under **Database Tools** with quick CSV
+and JSON buttons.
+

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -27,6 +27,7 @@ from backend.app.routes.r_shop_inventory import bp as shop_inventory_bp
 from backend.app.routes.r_stats import bp as stats_bp
 from backend.app.routes.r_story_arcs import bp as story_arcs_bp
 from backend.app.routes.r_timelines import bp as timelines_bp
+from backend.app.routes.r_export import bp as export_bp
 
 def create_app() -> Flask:
     app = Flask(__name__)
@@ -72,7 +73,8 @@ def create_app() -> Flask:
         shop_inventory_bp,
         stats_bp,
         story_arcs_bp,
-        timelines_bp
+        timelines_bp,
+        export_bp
     ]
     
     for blueprint in blueprints:

--- a/backend/app/routes/r_export.py
+++ b/backend/app/routes/r_export.py
@@ -1,0 +1,79 @@
+from flask import Blueprint, request, Response, abort
+import csv
+import json
+import io
+import zipfile
+import enum
+from backend.app.db.init_db import get_db_session
+from backend.app.models import ALL_MODELS
+
+bp = Blueprint('export', __name__)
+
+def serialize_row(row):
+    data = {}
+    for column in row.__table__.columns:
+        value = getattr(row, column.name)
+        if isinstance(value, enum.Enum):
+            data[column.name] = value.value
+        else:
+            data[column.name] = value
+    # Unreal Engine DataTables expect a 'Name' key
+    data['Name'] = data.get('id')
+    return data
+
+@bp.route('/api/export')
+def export_data():
+    fmt = request.args.get('format', 'csv').lower()
+    tables_param = request.args.get('tables')
+    selected = {t.strip() for t in tables_param.split(',')} if tables_param else None
+    db_session = get_db_session()
+    try:
+        if fmt == 'json':
+            payload = {}
+            for model in ALL_MODELS:
+                table_name = model.__tablename__
+                if selected and table_name not in selected:
+                    continue
+                rows = db_session.query(model).all()
+                payload[table_name] = [serialize_row(r) for r in rows]
+            json_bytes = json.dumps(payload, indent=2).encode('utf-8')
+            return Response(
+                json_bytes,
+                mimetype='application/json',
+                headers={'Content-Disposition': 'attachment; filename=export.json'}
+            )
+        else:
+            memory_file = io.BytesIO()
+            with zipfile.ZipFile(memory_file, 'w', zipfile.ZIP_DEFLATED) as zf:
+                for model in ALL_MODELS:
+                    table_name = model.__tablename__
+                    if selected and table_name not in selected:
+                        continue
+                    rows = db_session.query(model).all()
+                    if not rows:
+                        continue
+                    cols = [c.name for c in model.__table__.columns if c.name != 'id']
+                    headers = ['Name'] + cols
+                    csv_buffer = io.StringIO()
+                    writer = csv.DictWriter(csv_buffer, fieldnames=headers)
+                    writer.writeheader()
+                    for r in rows:
+                        data = serialize_row(r)
+                        row_dict = {'Name': data['Name']}
+                        for c in cols:
+                            val = data.get(c)
+                            if isinstance(val, (list, dict)):
+                                row_dict[c] = json.dumps(val)
+                            else:
+                                row_dict[c] = val
+                        writer.writerow(row_dict)
+                    zf.writestr(f'{table_name}.csv', csv_buffer.getvalue())
+            memory_file.seek(0)
+            return Response(
+                memory_file.getvalue(),
+                mimetype='application/zip',
+                headers={'Content-Disposition': 'attachment; filename=export.zip'}
+            )
+    finally:
+        db_session.close()
+

--- a/soa-editor/src/components/Sidebar.tsx
+++ b/soa-editor/src/components/Sidebar.tsx
@@ -20,7 +20,7 @@ import {
   HomeIcon, SparklesIcon, BeakerIcon, ChartBarIcon, UserGroupIcon, ChatBubbleLeftRightIcon,
   BookOpenIcon, MapIcon, UsersIcon, FlagIcon, CubeIcon, BuildingStorefrontIcon,
   ClipboardDocumentListIcon, PuzzlePieceIcon, AcademicCapIcon, ClockIcon, DocumentTextIcon,
-  Squares2X2Icon,
+  Squares2X2Icon, ArrowDownTrayIcon,
 } from '@heroicons/react/24/outline';
 import { Bars3Icon } from '@heroicons/react/24/outline';
 
@@ -77,7 +77,10 @@ function SortableSidebarItem({ to, label, icon: Icon, collapsed, hidden, groupLa
 const DEFAULT_GROUPS = [
   {
     label: 'System',
-    items: [ { to: '/', label: 'Home', icon: HomeIcon } ],
+    items: [
+      { to: '/', label: 'Home', icon: HomeIcon },
+      { to: '/db-tools', label: 'Database Tools', icon: ArrowDownTrayIcon },
+    ],
   },
   {
     label: 'Gameplay',

--- a/soa-editor/src/main.tsx
+++ b/soa-editor/src/main.tsx
@@ -26,6 +26,7 @@ import ShopsInventoryEditorPage from "./pages/ShopsInventoryEditor";
 import StatsEditorPage from "./pages/StatsEditor";
 import StoryArcsEditorPage from "./pages/StoryArcsEditor";
 import TimelinesEditorPage from "./pages/TimelinesEditor";
+import DatabaseToolsPage from "./pages/DatabaseTools";
 import './index.css';
 import './App.css';
 import Layout from './components/Layout';
@@ -68,6 +69,7 @@ const MainApp = () => {
             <Route path="stats" element={<StatsEditorPage />} />
             <Route path="story-arcs" element={<StoryArcsEditorPage />} />
             <Route path="timelines" element={<TimelinesEditorPage />} />
+            <Route path="db-tools" element={<DatabaseToolsPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/soa-editor/src/pages/DatabaseTools.tsx
+++ b/soa-editor/src/pages/DatabaseTools.tsx
@@ -1,0 +1,30 @@
+import DarkModeToggle from '../components/DarkModeToggle';
+
+export default function DatabaseToolsPage() {
+  const exportCsv = () => {
+    window.open('http://localhost:5000/api/export?format=csv', '_blank');
+  };
+
+  const exportJson = () => {
+    window.open('http://localhost:5000/api/export?format=json', '_blank');
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-100 dark:bg-gray-900 font-sans">
+      <main className="flex-1 p-8">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-3xl font-semibold text-primary dark:text-primary-content">Database Tools</h1>
+          <DarkModeToggle />
+        </div>
+        <section className="bg-white dark:bg-slate-800 p-6 rounded shadow max-w-md">
+          <h2 className="text-xl font-semibold mb-4">Export DB</h2>
+          <div className="flex gap-2 mb-2">
+            <button onClick={exportCsv} className="btn btn-sm btn-primary">CSV</button>
+            <button onClick={exportJson} className="btn btn-sm btn-secondary">JSON</button>
+          </div>
+          <p className="text-sm text-slate-500">CSV is recommended for Unreal Engine DataTables; JSON contains full structure.</p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/soa-editor/src/pages/IndexPageEditor.tsx
+++ b/soa-editor/src/pages/IndexPageEditor.tsx
@@ -22,6 +22,7 @@ import {
   ClockIcon,
   DocumentTextIcon,
   Squares2X2Icon,
+  ArrowDownTrayIcon,
 } from '@heroicons/react/24/outline';
 
 
@@ -49,6 +50,7 @@ const IndexPage = () => {
     { path: '/stats', name: 'Stats Editor' },
     { path: '/story-arcs', name: 'Story Arcs Editor' },
     { path: '/timelines', name: 'Timelines Editor' },
+    { path: '/db-tools', name: 'Database Tools' },
   ];
 
 const pageIcons: Record<string, React.ElementType> = {
@@ -74,6 +76,7 @@ const pageIcons: Record<string, React.ElementType> = {
   '/stats': ChartBarIcon,
   '/story-arcs': Squares2X2Icon,
   '/timelines': ClockIcon,
+  '/db-tools': ArrowDownTrayIcon,
 };
 
 


### PR DESCRIPTION
## Summary
- add `/api/export` endpoint to dump database tables as JSON or CSV
- register the new blueprint
- document export feature in README
- add Database Tools page in the frontend with CSV/JSON export buttons
- link Database Tools from the sidebar and index page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871108b7368832c9f732b78136af346